### PR TITLE
Update external link to Skaarhoj libraries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get the Wifitally to work you will also need to have some sort of Arduino Eth
 ## IDE Preparations
 
 * Download Arduino IDE if you do not already have it on your computer (www.arduino.cc)
-* Install the Skaarhoj Libraries (http://skaarhoj.com/wiki/index.php/ATEM\_Arduino\_Library)
+* Download and install the Skaarhoj Libraries (https://github.com/kasperskaarhoj/SKAARHOJ-Open-Engineering/tree/master/ArduinoLibs)
 * Patch your Ethernet library. (for details see [Details on the Ethernet lib](#few-words-on-the-ethernet-library))
 
 ## Usage


### PR DESCRIPTION
The Skaarhoj wiki seems to be down / removed. 
My proposal is to link to the still existing GitHub repo instead to download the library files. 

Also fixes #2. 